### PR TITLE
Remove sleeping in listen

### DIFF
--- a/quote_bot.py
+++ b/quote_bot.py
@@ -323,8 +323,6 @@ def quote_apropos(flag, arg):
 def listen():
   while 1:
 
-    time.sleep(1)
-
     ircmsg = ircsock.recv(2048)
     ircmsg = ircmsg.strip('\n\r')
 


### PR DESCRIPTION
There was a useless call to time.sleep in listen().
This sleep caused quote_bot to ignore messages that were sent immediately after another message.

Commit logs say this sleep was added to prevent stealing CPU, but recv should already make the thread wait until some data is available (unless you use non-blocking sockets, but it doesn't look like that in your code).
I believe the recv call does not take more CPU than sleep.