### PR TITLE
remove last os.popen

### DIFF
--- a/quote_bot.py
+++ b/quote_bot.py
@@ -306,7 +306,7 @@ def get_text_from_formatted(fmt):
 
 def quote_apropos(flag, arg):
   args = flag + " " + arg
-  return os.popen("/home/jumblesale/Code/quote_apropos/quote_apropos " + args).read()
+  return subprocess.check_output(["/home/jumblesale/Code/quote_apropos/quote_apropos", args])
   
 ## LISTENER FUNCTION
 


### PR DESCRIPTION
There was still a vulnerable os.popen in q-apropos. This replaces it with a subprocess.check_output with a list of arguments.
This should fix the shell injection vulnerability